### PR TITLE
wsgi.py

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for wiki project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/3.0/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wiki.settings')
+
+application = get_wsgi_application()


### PR DESCRIPTION
"""
WSGI config for wiki project.

It exposes the WSGI callable as a module-level variable named ``application``.

For more information on this file, see
https://docs.djangoproject.com/en/3.0/howto/deployment/wsgi/
"""

import os

from django.core.wsgi import get_wsgi_application

os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'wiki.settings')

application = get_wsgi_application()